### PR TITLE
Fix dynamic enum spelling

### DIFF
--- a/fern/01-guide/05-baml-advanced/dynamic-types.mdx
+++ b/fern/01-guide/05-baml-advanced/dynamic-types.mdx
@@ -392,7 +392,7 @@ tb.add_baml("""
   }
 
   // Modifies the existing @@dynamic Category enum to add a new variant.
-  dynmic enum Category {
+  dynamic enum Category {
     VALUE5
   }
 """)
@@ -416,7 +416,7 @@ tb.addBaml(`
   }
 
   // Modifies the existing @@dynamic Category enum to add a new variant.
-  dynmic enum Category {
+  dynamic enum Category {
     VALUE5
   }
 `)
@@ -440,7 +440,7 @@ tb.add_baml("
   }
 
   // Modifies the existing @@dynamic Category enum to add a new variant.
-  dynmic enum Category {
+  dynamic enum Category {
     VALUE5
   }
 ")


### PR DESCRIPTION
## Summary
- fix typos `dynmic enum` -> `dynamic enum` in dynamic types guide
